### PR TITLE
Commands: Kill command

### DIFF
--- a/pymine/logic/cmds/kill.py
+++ b/pymine/logic/cmds/kill.py
@@ -22,9 +22,6 @@ from pymine.server import server
 async def kill(uuid, name: str):
     """Kills a player."""
 
-    server.console.info(f"Kill was executed. {uuid=}, {name=}")
-    server.console.info(f"{server.playerio.cache=}")
-
     player = None
 
     for i in server.playerio.cache.values():
@@ -35,8 +32,7 @@ async def kill(uuid, name: str):
         server.console.error('No player with username "' + name + '" found.')
         return
 
-    server.console.info(player.stream)
-    #server.console.info(player.data)
+    server.console.info("Killing player " + player.username + "...")
 
     await server.send_packet(
         player.stream,

--- a/pymine/logic/cmds/kill.py
+++ b/pymine/logic/cmds/kill.py
@@ -1,0 +1,24 @@
+# A flexible and fast Minecraft server software written completely in Python.
+# Copyright (C) 2022 PyMine
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from pymine.server import server
+
+
+@server.api.commands.on_command(name="kill", node="minecraft.cmd.kill")
+async def kill(uuid, name: str):
+    """Kills a player."""
+
+    server.console.debug(f"Kill was executed. {uuid=}, {name=}")

--- a/pymine/logic/cmds/kill.py
+++ b/pymine/logic/cmds/kill.py
@@ -14,10 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import pymine.net.packets as packets
 from pymine.server import server
 
 
-@server.api.commands.on_command(name="kill", node="minecraft.cmd.kill")
+@server.api.commands.on_command(name="kill", node="pymine.cmds.kill")
 async def kill(uuid, name: str):
     """Kills a player."""
 
@@ -25,13 +26,23 @@ async def kill(uuid, name: str):
     server.console.info(f"{server.playerio.cache=}")
 
     player = None
-    
+
     for i in server.playerio.cache.values():
         if i.username == name:
             player = i
             break
     else:
-        server.console.error("No player with username \"" + name + "\" found.")
+        server.console.error('No player with username "' + name + '" found.')
         return
 
     server.console.info(player.stream)
+    #server.console.info(player.data)
+
+    await server.send_packet(
+        player.stream,
+        packets.play.player.PlayUpdateHealth(
+            0,
+            20,
+            0.5
+        )
+    )

--- a/pymine/logic/cmds/kill.py
+++ b/pymine/logic/cmds/kill.py
@@ -21,4 +21,17 @@ from pymine.server import server
 async def kill(uuid, name: str):
     """Kills a player."""
 
-    server.console.debug(f"Kill was executed. {uuid=}, {name=}")
+    server.console.info(f"Kill was executed. {uuid=}, {name=}")
+    server.console.info(f"{server.playerio.cache=}")
+
+    player = None
+    
+    for i in server.playerio.cache.values():
+        if i.username == name:
+            player = i
+            break
+    else:
+        server.console.error("No player with username \"" + name + "\" found.")
+        return
+
+    server.console.info(player.stream)

--- a/pymine/logic/cmds/kill.py
+++ b/pymine/logic/cmds/kill.py
@@ -37,8 +37,6 @@ async def kill(uuid, name: str):
     await server.send_packet(
         player.stream,
         packets.play.player.PlayUpdateHealth(
-            0,
-            20,
-            0.5
-        )
+            0, player.data["foodLevel"].data, player.data["foodSaturationLevel"].data
+        ),
     )


### PR DESCRIPTION
Add a `kill` command for killing players.

Sets a player's health to 0 using the PlayUpdateHealth packet.

Syntax:
`kill <username>`